### PR TITLE
NewsCategoryNotFoundException does not exist

### DIFF
--- a/libraries/Exceptions/NewsCategoryNotFoundException.php
+++ b/libraries/Exceptions/NewsCategoryNotFoundException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace BNETDocs\Libraries\Exceptions;
+
+use \BNETDocs\Libraries\Exceptions\BNETDocsException;
+use \BNETDocs\Libraries\Logger;
+use \Exception;
+
+class NewsCategoryNotFoundException extends BNETDocsException {
+
+  public function __construct($query, Exception &$prev_ex = null) {
+    parent::__construct("News category not found", 12, $prev_ex);
+    Logger::logMetric("query", $query);
+  }
+
+}

--- a/libraries/Exceptions/Reference.md
+++ b/libraries/Exceptions/Reference.md
@@ -3,16 +3,17 @@ Error Reference
 
 All of the following errors are subclassed from the `BNETDocsException` class.
 
-| Error Code | Error Name                     | Error Message                                        |
-| ---------- | ------------------------------ | ---------------------------------------------------- |
-| 1          | `ClassNotFoundException`       | Required class `$className` not found                |
-| 2          | `ControllerNotFoundException`  | Unable to find a suitable controller given the path  |
-| 3          | `IncorrectModelException`      | Incorrect model provided to view                     |
-| 4          | `TemplateNotFoundException`    | Unable to locate template required to load this view |
-| 5          | `DatabaseUnavailableException` | All configured databases are unavailable             |
-| 6          | `QueryException`               | `$message`                                           |
-| 7          | `UserNotFoundException`        | User not found                                       |
-| 8          | `NewsPostNotFoundException`    | News post not found                                  |
-| 9          | `ServerNotFoundException`      | Server not found                                     |
-| 10         | `ServerTypeNotFoundException`  | Server type not found                                |
-| 11         | `UserProfileNotFoundException` | User profile not found                               |
+| Error Code | Error Name                      | Error Message                                        |
+| ---------- | ------------------------------- | ---------------------------------------------------- |
+| 1          | `ClassNotFoundException`        | Required class `$className` not found                |
+| 2          | `ControllerNotFoundException`   | Unable to find a suitable controller given the path  |
+| 3          | `IncorrectModelException`       | Incorrect model provided to view                     |
+| 4          | `TemplateNotFoundException`     | Unable to locate template required to load this view |
+| 5          | `DatabaseUnavailableException`  | All configured databases are unavailable             |
+| 6          | `QueryException`                | `$message`                                           |
+| 7          | `UserNotFoundException`         | User not found                                       |
+| 8          | `NewsPostNotFoundException`     | News post not found                                  |
+| 9          | `ServerNotFoundException`       | Server not found                                     |
+| 10         | `ServerTypeNotFoundException`   | Server type not found                                |
+| 11         | `UserProfileNotFoundException`  | User profile not found                               |
+| 12         | `NewsCategoryNotFoundException` | News category not found                              |


### PR DESCRIPTION
The `NewsCategory` class throws a `NewsCategoryNotFoundException` at the following line:
https://github.com/BNETDocs/bnetdocs-web/blob/6eb993402a7ba0f76964b41b703b375afea3e3d5/libraries/NewsCategory.php#L130

However, it is not present in the tree:
https://github.com/BNETDocs/bnetdocs-web/tree/6eb993402a7ba0f76964b41b703b375afea3e3d5/libraries/Exceptions
