### PR TITLE
Better/fixed missing user handling

### DIFF
--- a/src/libraries/Comment.php
+++ b/src/libraries/Comment.php
@@ -219,8 +219,7 @@ class Comment implements JsonSerializable {
   }
 
   public function getUser() {
-    if (is_null($this->user_id)) return null;
-    return new User($this->user_id);
+    return User::findUserById($this->user_id);
   }
 
   public function getUserId() {

--- a/src/libraries/Document.php
+++ b/src/libraries/Document.php
@@ -265,8 +265,7 @@ class Document {
   }
 
   public function getUser() {
-    if (is_null($this->user_id)) return null;
-    return new User($this->user_id);
+    return User::findUserById($this->user_id);
   }
 
   public function getUserId() {

--- a/src/libraries/NewsPost.php
+++ b/src/libraries/NewsPost.php
@@ -302,8 +302,7 @@ class NewsPost {
   }
 
   public function getUser() {
-    if (is_null($this->user_id)) return null;
-    return new User($this->user_id);
+    return User::findUserById($this->user_id);
   }
 
   public function getUserId() {

--- a/src/libraries/Packet.php
+++ b/src/libraries/Packet.php
@@ -523,11 +523,7 @@ class Packet implements JsonSerializable {
   }
 
   public function getUser() {
-    if ( is_null( $this->user_id )) {
-      return null;
-    }
-
-    return new User( $this->user_id );
+    return User::findUserById($this->user_id);
   }
 
   public function getUserId() {

--- a/src/libraries/Server.php
+++ b/src/libraries/Server.php
@@ -177,8 +177,7 @@ class Server implements JsonSerializable {
   }
 
   public function getUser() {
-    if (is_null($this->user_id)) return null;
-    return new User($this->user_id);
+    return User::findUserById($this->user_id);
   }
 
   public function getUserId() {

--- a/src/libraries/User.php
+++ b/src/libraries/User.php
@@ -341,6 +341,16 @@ class User implements JsonSerializable {
     return ($this->options_bitmask & $acl);
   }
 
+  public static function findUserById($user_id) {
+    if (is_null($user_id)) return null;
+    
+    try {
+      return new User($user_id);
+    } catch (UserNotFoundException $e) {
+      return null;
+    }
+  }
+  
   public static function &getAllUsers(
     $order = null, $limit = null, $index = null
   ) {

--- a/src/templates/Comment/Section.inc.phtml
+++ b/src/templates/Comment/Section.inc.phtml
@@ -1,0 +1,45 @@
+<?php
+
+namespace BNETDocs\Templates\Comment;
+
+use \BNETDocs\Libraries\Comment;
+use \BNETDocs\Libraries\User;
+
+use \CarlBennett\MVC\Libraries\Common;
+
+
+?>
+        <header><a name="comments">Comments</a></header>
+        <section>
+<?php if (!$comments) { ?>
+          <p class="center"><em>no one has commented yet.</em></p>
+<?php } else {
+$c_edit_visible_master   = ($logged_in && ($logged_in->getOptionsBitmask() & User::OPTION_ACL_COMMENT_MODIFY));
+$c_delete_visible_master = ($logged_in && ($logged_in->getOptionsBitmask() & User::OPTION_ACL_COMMENT_DELETE));
+?>
+          <table class="comments"><tbody>
+<?php foreach ($comments as $c) {
+        $c_id          = $c->getId();
+        $c_user        = $c->getUser();
+        $c_user_id     = $c->getUserId();
+
+        $c_edit_visible = ($c_user_id == $logged_in_id || $c_edit_visible_master);
+        $c_delete_visible = ($c_user_id == $logged_in_id || $c_delete_visible_master);
+?>
+            <tr><td><?php if ($c_user) { ?><a href="<?php echo $c_user->getURI(); ?>"><img class="avatar" src="<?php echo $c_user->getAvatarURI(22); ?>"/> <?php echo filter_var($c_user->getName(), FILTER_SANITIZE_STRING); ?></a><?php } else { ?>Anonymous<?php } ?><br/><time class="comment_timestamp" datetime="<?php echo $c->getCreatedDateTime()->format("c"); ?>"><?php echo $c->getCreatedDateTime()->format("D M j, Y g:ia T"); ?></time><?php if ($c_delete_visible) { ?><a class="button comment_button" href="<?php echo Common::relativeUrlToAbsolute("/comment/delete?id=" . urlencode($c_id)); ?>">Delete</a><?php } if ($c_edit_visible) { ?><a class="button comment_button" href="<?php echo Common::relativeUrlToAbsolute("/comment/edit?id=" . urlencode($c_id)); ?>">Edit</a><?php } ?></td><td><?php echo $c->getContent(true); ?></td></tr>
+<?php } ?>
+          </tbody></table>
+<?php } ?>
+        </section>
+<?php if ($logged_in) { ?>
+        <section>
+          <hr/>
+          <form method="POST" action="<?php echo Common::relativeUrlToAbsolute("/comment/create"); ?>">
+            <input type="hidden" name="parent_type" value="<?php echo $comment_parent_type; ?>"/>
+            <input type="hidden" name="parent_id" value="<?php echo $object_id; ?>"/>
+            <p class="center"><label for="comment-content">Comment on this post:</label></p>
+            <p class="center"><textarea id="comment-content" name="content" cols="80" rows="5"></textarea></p>
+            <p class="center"><input type="submit" value="Comment"/></p>
+          </form>
+        </section>
+<?php } ?>

--- a/src/templates/Document/View.phtml
+++ b/src/templates/Document/View.phtml
@@ -32,10 +32,7 @@ if ($object) {
     $object->getContent(true), FILTER_SANITIZE_STRING
   )), "\n", 300);
 
-  $user_name   = $object->getUser()->getName();
-  $user_id     = $object->getUserId();
-  $user_url    = $object->getUser()->getURI();
-  $user_avatar = $object->getUser()->getAvatarURI(22);
+  $user = $object->getUser();
 
 }
 
@@ -73,8 +70,8 @@ require("./header.inc.phtml");
 <?php } else { ?>
           <span class="float-right"><time datetime="<?php echo $object->getCreatedDateTime()->format('c'); ?>"><?php echo $object->getCreatedDateTime()->format("l, F j, Y"); ?></time></span>
 <?php } ?>
-<?php if ($user_id !== null) { ?>
-          <span><a href="<?php echo $user_url; ?>"><img class="avatar" src="<?php echo $user_avatar; ?>"/> <?php echo filter_var($user_name, FILTER_SANITIZE_STRING); ?></a></span>
+<?php if ($user !== null) { ?>
+          <span><a href="<?php echo $user->getURI(); ?>"><img class="avatar" src="<?php echo $user->getAvatarURI(22); ?>"/> <?php echo filter_var($user->getName(), FILTER_SANITIZE_STRING); ?></a></span>
 <?php } ?>
         </footer>
       </article>
@@ -91,15 +88,12 @@ $c_delete_visible_master = ($logged_in && ($logged_in->getOptionsBitmask() & Use
 <?php foreach ($comments as $c) {
         $c_id          = $c->getId();
         $c_user        = $c->getUser();
-        $c_user_name   = $c_user->getName();
         $c_user_id     = $c->getUserId();
-        $c_user_url    = $c_user->getURI();
-        $c_user_avatar = $c_user->getAvatarURI(22);
 
         $c_edit_visible = ($c_user_id == $logged_in_id || $c_edit_visible_master);
         $c_delete_visible = ($c_user_id == $logged_in_id || $c_delete_visible_master);
 ?>
-            <tr><td><a href="<?php echo $c_user_url; ?>"><img class="avatar" src="<?php echo $c_user_avatar; ?>"/> <?php echo filter_var($c_user_name, FILTER_SANITIZE_STRING); ?></a><br/><time class="comment_timestamp" datetime="<?php echo $c->getCreatedDateTime()->format("c"); ?>"><?php echo $c->getCreatedDateTime()->format("D M j, Y g:ia T"); ?></time><?php if ($c_delete_visible) { ?><a class="button comment_button" href="<?php echo Common::relativeUrlToAbsolute("/comment/delete?id=" . urlencode($c_id)); ?>">Delete</a><?php } if ($c_edit_visible) { ?><a class="button comment_button" href="<?php echo Common::relativeUrlToAbsolute("/comment/edit?id=" . urlencode($c_id)); ?>">Edit</a><?php } ?></td><td><?php echo $c->getContent(true); ?></td></tr>
+            <tr><td><?php if ($c_user) { ?><a href="<?php echo $c_user->getURI(); ?>"><img class="avatar" src="<?php echo $c_user->getAvatarURI(22); ?>"/> <?php echo filter_var($c_user->getName(), FILTER_SANITIZE_STRING); ?></a><?php } else { ?>Anonymous<?php } ?><br/><time class="comment_timestamp" datetime="<?php echo $c->getCreatedDateTime()->format("c"); ?>"><?php echo $c->getCreatedDateTime()->format("D M j, Y g:ia T"); ?></time><?php if ($c_delete_visible) { ?><a class="button comment_button" href="<?php echo Common::relativeUrlToAbsolute("/comment/delete?id=" . urlencode($c_id)); ?>">Delete</a><?php } if ($c_edit_visible) { ?><a class="button comment_button" href="<?php echo Common::relativeUrlToAbsolute("/comment/edit?id=" . urlencode($c_id)); ?>">Edit</a><?php } ?></td><td><?php echo $c->getContent(true); ?></td></tr>
 <?php } ?>
           </tbody></table>
 <?php } ?>

--- a/src/templates/Document/View.phtml
+++ b/src/templates/Document/View.phtml
@@ -76,43 +76,15 @@ require("./header.inc.phtml");
         </footer>
       </article>
       <article>
-        <header><a name="comments">Comments</a></header>
-        <section>
-<?php if (!$comments) { ?>
-          <p class="center"><em>no one has commented yet.</em></p>
-<?php } else {
-$c_edit_visible_master   = ($logged_in && ($logged_in->getOptionsBitmask() & User::OPTION_ACL_COMMENT_MODIFY));
-$c_delete_visible_master = ($logged_in && ($logged_in->getOptionsBitmask() & User::OPTION_ACL_COMMENT_DELETE));
-?>
-          <table class="comments"><tbody>
-<?php foreach ($comments as $c) {
-        $c_id          = $c->getId();
-        $c_user        = $c->getUser();
-        $c_user_id     = $c->getUserId();
+<?php 
 
-        $c_edit_visible = ($c_user_id == $logged_in_id || $c_edit_visible_master);
-        $c_delete_visible = ($c_user_id == $logged_in_id || $c_delete_visible_master);
-?>
-            <tr><td><?php if ($c_user) { ?><a href="<?php echo $c_user->getURI(); ?>"><img class="avatar" src="<?php echo $c_user->getAvatarURI(22); ?>"/> <?php echo filter_var($c_user->getName(), FILTER_SANITIZE_STRING); ?></a><?php } else { ?>Anonymous<?php } ?><br/><time class="comment_timestamp" datetime="<?php echo $c->getCreatedDateTime()->format("c"); ?>"><?php echo $c->getCreatedDateTime()->format("D M j, Y g:ia T"); ?></time><?php if ($c_delete_visible) { ?><a class="button comment_button" href="<?php echo Common::relativeUrlToAbsolute("/comment/delete?id=" . urlencode($c_id)); ?>">Delete</a><?php } if ($c_edit_visible) { ?><a class="button comment_button" href="<?php echo Common::relativeUrlToAbsolute("/comment/edit?id=" . urlencode($c_id)); ?>">Edit</a><?php } ?></td><td><?php echo $c->getContent(true); ?></td></tr>
-<?php } ?>
-          </tbody></table>
-<?php } ?>
-        </section>
-<?php if ($logged_in) { ?>
-        <section>
-          <hr/>
-          <form method="POST" action="<?php echo Common::relativeUrlToAbsolute("/comment/create"); ?>">
-            <input type="hidden" name="parent_type" value="<?php echo Comment::PARENT_TYPE_DOCUMENT; ?>"/>
-            <input type="hidden" name="parent_id" value="<?php echo $object_id; ?>"/>
-            <p class="center"><label for="comment-content">Comment on this post:</label></p>
-            <p class="center"><textarea id="comment-content" name="content" cols="80" rows="5"></textarea></p>
-            <p class="center"><input type="submit" value="Comment"/></p>
-          </form>
-        </section>
-<?php } ?>
-<?php } else { ?>
+$comment_parent_type = Comment::PARENT_TYPE_DOCUMENT;
+require("./Comment/Section.inc.phtml");
+
+      } else { ?>
         <header class="red"><?php echo filter_var($title, FILTER_SANITIZE_STRING); ?></header>
         <section class="red"><?php echo filter_var($description, FILTER_SANITIZE_STRING); ?></section>
 <?php } ?>
       </article>
-<?php require("./footer.inc.phtml"); ?>
+
+require("./footer.inc.phtml"); ?>

--- a/src/templates/News/View.phtml
+++ b/src/templates/News/View.phtml
@@ -86,44 +86,12 @@ require("./header.inc.phtml");
         </footer>
       </article>
       <article>
-        <header><a name="comments">Comments</a></header>
-        <section>
-<?php if (!$comments) { ?>
-          <p class="center"><em>no one has commented yet.</em></p>
-<?php } else {
-$c_edit_visible_master   = ($logged_in && ($logged_in->getOptionsBitmask() & User::OPTION_ACL_COMMENT_MODIFY));
-$c_delete_visible_master = ($logged_in && ($logged_in->getOptionsBitmask() & User::OPTION_ACL_COMMENT_DELETE));
-?>
-          <table class="comments"><tbody>
-<?php foreach ($comments as $c) {
-        $c_id          = $c->getId();
-        $c_user        = $c->getUser();
-        $c_user_name   = $c_user->getName();
-        $c_user_id     = $c->getUserId();
-        $c_user_url    = $c_user->getURI();
-        $c_user_avatar = $c_user->getAvatarURI(22);
+<?php
 
-        $c_edit_visible = ($c_user_id == $logged_in_id || $c_edit_visible_master);
-        $c_delete_visible = ($c_user_id == $logged_in_id || $c_delete_visible_master);
-?>
-            <tr><td><a href="<?php echo $c_user_url; ?>"><img class="avatar" src="<?php echo $c_user_avatar; ?>"/> <?php echo filter_var($c_user_name, FILTER_SANITIZE_STRING); ?></a><br/><time class="comment_timestamp" datetime="<?php echo $c->getCreatedDateTime()->format("c"); ?>"><?php echo $c->getCreatedDateTime()->format("D M j, Y g:ia T"); ?></time><?php if ($c_delete_visible) { ?><a class="button comment_button" href="<?php echo Common::relativeUrlToAbsolute("/comment/delete?id=" . urlencode($c_id)); ?>">Delete</a><?php } if ($c_edit_visible) { ?><a class="button comment_button" href="<?php echo Common::relativeUrlToAbsolute("/comment/edit?id=" . urlencode($c_id)); ?>">Edit</a><?php } ?></td><td><?php echo $c->getContent(true); ?></td></tr>
-<?php } ?>
-          </tbody></table>
-<?php } ?>
-        </section>
-<?php if ($logged_in) { ?>
-        <section>
-          <hr/>
-          <form method="POST" action="<?php echo Common::relativeUrlToAbsolute("/comment/create"); ?>">
-            <input type="hidden" name="parent_type" value="<?php echo Comment::PARENT_TYPE_NEWS_POST; ?>"/>
-            <input type="hidden" name="parent_id" value="<?php echo $object_id; ?>"/>
-            <p class="center"><label for="comment-content">Comment on this post:</label></p>
-            <p class="center"><textarea id="comment-content" name="content" cols="80" rows="5"></textarea></p>
-            <p class="center"><input type="submit" value="Comment"/></p>
-          </form>
-        </section>
-<?php } ?>
-<?php } else { ?>
+$comment_parent_type = Comment::PARENT_TYPE_NEWS_POST;
+require("./Comment/Section.inc.phtml");
+
+      } else { ?>
         <header class="red"><?php echo filter_var($title, FILTER_SANITIZE_STRING); ?></header>
         <section class="red"><?php echo filter_var($description, FILTER_SANITIZE_STRING); ?></section>
 <?php } ?>

--- a/src/templates/Packet/View.phtml
+++ b/src/templates/Packet/View.phtml
@@ -120,44 +120,12 @@ require("./header.inc.phtml");
         </footer>
       </article>
       <article>
-        <header><a name="comments">Comments</a></header>
-        <section>
-<?php if (!$comments) { ?>
-          <p class="center"><em>no one has commented yet.</em></p>
-<?php } else {
-$c_edit_visible_master   = ($logged_in && ($logged_in->getOptionsBitmask() & User::OPTION_ACL_COMMENT_MODIFY));
-$c_delete_visible_master = ($logged_in && ($logged_in->getOptionsBitmask() & User::OPTION_ACL_COMMENT_DELETE));
-?>
-          <table class="comments"><tbody>
-<?php foreach ($comments as $c) {
-        $c_id          = $c->getId();
-        $c_user        = $c->getUser();
-        $c_user_name   = $c_user->getName();
-        $c_user_id     = $c->getUserId();
-        $c_user_url    = $c_user->getURI();
-        $c_user_avatar = $c_user->getAvatarURI(22);
+<?php
 
-        $c_edit_visible = ($c_user_id == $logged_in_id || $c_edit_visible_master);
-        $c_delete_visible = ($c_user_id == $logged_in_id || $c_delete_visible_master);
-?>
-            <tr><td><a href="<?php echo $c_user_url; ?>"><img class="avatar" src="<?php echo $c_user_avatar; ?>"/> <?php echo filter_var($c_user_name, FILTER_SANITIZE_STRING); ?></a><br/><time class="comment_timestamp" datetime="<?php echo $c->getCreatedDateTime()->format("c"); ?>"><?php echo $c->getCreatedDateTime()->format("D M j, Y g:ia T"); ?></time><?php if ($c_delete_visible) { ?><a class="button comment_button" href="<?php echo Common::relativeUrlToAbsolute("/comment/delete?id=" . urlencode($c_id)); ?>">Delete</a><?php } if ($c_edit_visible) { ?><a class="button comment_button" href="<?php echo Common::relativeUrlToAbsolute("/comment/edit?id=" . urlencode($c_id)); ?>">Edit</a><?php } ?></td><td><?php echo $c->getContent(true); ?></td></tr>
-<?php } ?>
-          </tbody></table>
-<?php } ?>
-        </section>
-<?php if ($logged_in) { ?>
-        <section>
-          <hr/>
-          <form method="POST" action="<?php echo Common::relativeUrlToAbsolute("/comment/create"); ?>">
-            <input type="hidden" name="parent_type" value="<?php echo Comment::PARENT_TYPE_PACKET; ?>"/>
-            <input type="hidden" name="parent_id" value="<?php echo $object_id; ?>"/>
-            <p class="center"><label for="comment-content">Comment on this post:</label></p>
-            <p class="center"><textarea id="comment-content" name="content" cols="80" rows="5"></textarea></p>
-            <p class="center"><input type="submit" value="Comment"/></p>
-          </form>
-        </section>
-<?php } ?>
-<?php } else { ?>
+$comment_parent_type = Comment::PARENT_TYPE_PACKET;
+require("./Comment/Section.inc.phtml");
+
+      } else { ?>
         <header class="red"><?php echo filter_var($title, FILTER_SANITIZE_STRING); ?></header>
         <section class="red"><?php echo filter_var($description, FILTER_SANITIZE_STRING); ?></section>
 <?php } ?>


### PR DESCRIPTION
Several objects with getUser() functions (document, packet, etc) were expecting a null user if the ID wasn't found, but a UserNotFoundException was being thrown instead which prevented some index pages from being displayed.

Adds User::findUserById($id) function to libraries\User. Returns the user object or null. Updates some objects to use this.