### PR TITLE
Check if a username has already been taken during registration.

### DIFF
--- a/src/controllers/User/Register.php
+++ b/src/controllers/User/Register.php
@@ -136,6 +136,13 @@ class Register extends Controller {
         return;
       }
     } catch (UserNotFoundException $e) {}
+    
+    try {
+      if (User::findIdByUsername($username)) {
+        $model->error = "USERNAME_TAKEN";
+        return;
+      }
+    } catch (UserNotFoundException $e) {}
 
     try {
 

--- a/src/templates/User/Register.phtml
+++ b/src/templates/User/Register.phtml
@@ -70,6 +70,10 @@ switch ($this->getContext()->error) {
     $af      = "email";
     $message = "The email address is already in use, use another.";
     break;
+  case "USERNAME_TAKEN":
+    $af      = "username";
+    $message = "That username is taken, try another.";
+    break;
   case "INTERNAL_ERROR":
     $af      = null;
     $message = "An internal error occurred while processing your request. "


### PR DESCRIPTION
Returns a more detailed message to the user instead of the generic server error.